### PR TITLE
use find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 """
 The setup.py script for energy_py
@@ -16,13 +16,7 @@ setup(name='energy_py',
 
       url='http://adgefficiency.com/',
 
-      packages=['energy_py',
-                'energy_py.agents',
-                'energy_py.envs',
-                'energy_py.envs.flex',
-                'energy_py.envs.battery',
-                'energy_py.experiments',
-                'energy_py.scripts'],
+      packages=find_packages(exclude=['tests', 'tests.*']),
 
       package_data = {'':['*.csv']},
       install_requires=[]


### PR DESCRIPTION
In `setup.py`, Instead of listing all directories which constitute your packages, you can use [setuptools.find-packages](http://setuptools.readthedocs.io/en/latest/setuptools.html#using-find-packages) to walk the directory structure and add any directory with a `__init__.py` file as a package.

We can also use the `exclude` kwarg to exclude the test folders which contain `__init__py` but should not be part of the package.