### PR TITLE
installing example datasets as package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ setup(name='energy_py',
 
       packages=find_packages(exclude=['tests', 'tests.*']),
 
-      package_data = {'':['*.csv']},
+      package_data={'energy_py': ['experiments/datasets/example/*.csv']},
+      include_package_data=True,
+
       setup_requires=['pytest-runner'],
       tests_require=['pytest'],
       install_requires=[]


### PR DESCRIPTION
Installs the csv files in experiment examples dataset as package data. This should resolve the issue referenced in https://github.com/ADGEfficiency/energy_py/issues/34